### PR TITLE
[postgres-links] Postgres service linked apps

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -6,4 +6,8 @@
   .link {
     @apply underline text-blue-600 hover:text-blue-500
   }
+
+  .title {
+    @apply text-2xl font-bold mb-2
+  }
 }

--- a/app/controllers/dokku/postgres_links_controller.rb
+++ b/app/controllers/dokku/postgres_links_controller.rb
@@ -1,0 +1,25 @@
+module Dokku
+  class PostgresLinksController < ApplicationController
+    def new
+      @postgres = Postgres.new(service: params[:postgre_service])
+      @available_app_names = Dokku::App.all.map(&:name) - @postgres.links
+    end
+
+    def create
+      @postgres = Postgres.new(service: params[:postgre_service])
+
+      if @postgres.link(link_params[:app_name])
+        redirect_to dokku_postgre_path(@postgres)
+      else
+        @available_app_names = Dokku::App.all.map(&:name) - @postgres.links
+        render :new
+      end
+    end
+
+    private
+
+    def link_params
+      params.require(:postgres_link).permit(:app_name)
+    end
+  end
+end

--- a/app/lib/dokku/postgres.rb
+++ b/app/lib/dokku/postgres.rb
@@ -38,6 +38,12 @@ module Dokku
       result.split("\n")
     end
 
+    def link(app_name)
+      Ssh.new.exec("postgres:link #{service} #{app_name} &") # & to run in background
+
+      true
+    end
+
     def save
       result = self.class.create(service: service)
       errors.merge!(result.errors)

--- a/app/lib/dokku/postgres.rb
+++ b/app/lib/dokku/postgres.rb
@@ -33,6 +33,11 @@ module Dokku
       Ssh.new.exec("postgres:info #{service}")
     end
 
+    def links
+      result = Ssh.new.exec("postgres:links #{service}")
+      result.split("\n")
+    end
+
     def save
       result = self.class.create(service: service)
       errors.merge!(result.errors)

--- a/app/models/ssh.rb
+++ b/app/models/ssh.rb
@@ -16,6 +16,10 @@ class Ssh
 
   private
 
+  def port
+    ENV.fetch("DOKKU_PORT", 22)
+  end
+
   def private_path
     ssh_key.private_path
   end
@@ -25,7 +29,7 @@ class Ssh
   end
 
   def ssh_prefix
-    "ssh -o StrictHostKeyChecking=no -o PasswordAuthentication=no -i #{private_path} #{user}@#{host}"
+    "ssh -o StrictHostKeyChecking=no -o PasswordAuthentication=no -i #{private_path} #{user}@#{host} -p #{port}"
   end
 
   def user
@@ -33,6 +37,6 @@ class Ssh
   end
 
   def host
-    Rails.env.production? ? "localhost" : "dokku.me"
+    Rails.env.production? ? "localhost" : ENV.fetch("DOKKU_HOST", "dokku.me")
   end
 end

--- a/app/views/dokku/app_logs/index.html.erb
+++ b/app/views/dokku/app_logs/index.html.erb
@@ -1,4 +1,4 @@
-<h1 class="text-xl mb-2"><%= link_to @app.name , dokku_app_path(@app.name) %> | <%= link_to "Logs", dokku_app_app_logs_path(@app.name) %></h1>
+<h1 class="title"><%= link_to @app.name , dokku_app_path(@app.name) %> | <%= link_to "Logs", dokku_app_app_logs_path(@app.name) %></h1>
 
 <main class="py-4">
   <code>

--- a/app/views/dokku/apps/index.html.erb
+++ b/app/views/dokku/apps/index.html.erb
@@ -1,4 +1,4 @@
-<h1 class="text-xl mb-2">Apps</h1>
+<h1 class="title">Apps</h1>
 
 <main class="py-4">
   <% if @apps.any? %>

--- a/app/views/dokku/apps/show.html.erb
+++ b/app/views/dokku/apps/show.html.erb
@@ -1,4 +1,4 @@
-<h1 class="text-xl mb-2"><%= @app.name %></h1>
+<h1 class="title"><%= @app.name %></h1>
 
 <main class="">
   <div class="mb-2">

--- a/app/views/dokku/postgres/_links.html.erb
+++ b/app/views/dokku/postgres/_links.html.erb
@@ -1,0 +1,11 @@
+<%= turbo_frame_tag "postgres-#{postgres.service}-links" do %>
+  <p>Links</p>
+
+  <% if postgres.links.blank? %>
+    <p class="text-gray-500">No links</p>
+  <% end %>
+
+  <% postgres.links.each do |link| %>
+    <%= link_to link, dokku_app_path(link), class: "link", target: :_top %>
+  <% end %>
+<% end %>

--- a/app/views/dokku/postgres/_links.html.erb
+++ b/app/views/dokku/postgres/_links.html.erb
@@ -1,11 +1,17 @@
-<%= turbo_frame_tag "postgres-#{postgres.service}-links" do %>
-  <p>Links</p>
+<p>Linked apps</p>
 
-  <% if postgres.links.blank? %>
-    <p class="text-gray-500">No links</p>
-  <% end %>
+<% if postgres.links.blank? %>
+  <p class="text-gray-500">No links</p>
+<% end %>
 
+<%= turbo_frame_tag "new_postgre_link" do %>
   <% postgres.links.each do |link| %>
-    <%= link_to link, dokku_app_path(link), class: "link", target: :_top %>
+    <p>
+      <%= link_to link, dokku_app_path(link), class: "link", target: :_top %>
+    </p>
   <% end %>
+
+  <p>
+    <%= link_to "Link an app", new_dokku_postgre_links_path(postgres), class: "link" %>
+  </p>
 <% end %>

--- a/app/views/dokku/postgres/_links.html.erb
+++ b/app/views/dokku/postgres/_links.html.erb
@@ -1,10 +1,10 @@
 <p>Linked apps</p>
 
-<% if postgres.links.blank? %>
-  <p class="text-gray-500">No links</p>
-<% end %>
-
 <%= turbo_frame_tag "new_postgre_link" do %>
+  <% if postgres.links.blank? %>
+    <p class="text-gray-500">No links</p>
+  <% end %>
+
   <% postgres.links.each do |link| %>
     <p>
       <%= link_to link, dokku_app_path(link), class: "link", target: :_top %>

--- a/app/views/dokku/postgres/index.html.erb
+++ b/app/views/dokku/postgres/index.html.erb
@@ -1,4 +1,4 @@
-<h1 class="text-xl mb-2">Postgres</h1>
+<h1 class="title">Postgres</h1>
 
 <main class="py-4">
   <% if @postgres_services.any? %>

--- a/app/views/dokku/postgres/show.html.erb
+++ b/app/views/dokku/postgres/show.html.erb
@@ -1,9 +1,12 @@
 <% @postgres.errors.to_hash(true).each do |attr, errors| %>
   <%= render "application/notification", message: errors.join(". ") %>
 <% end %>
-<h1 class="text-xl mb-2"><%= @postgres.service %></h1>
+<h1 class="title"><%= @postgres.service %></h1>
 
 <main class="">
+  <div class="mb-2">
+    <%= render "links", postgres: @postgres %>
+  </div>
   <div class="mb-2">
     <%= link_to "Destroy", dokku_postgre_path(@postgres.service), class: "link", data: { turbo_method: :delete, turbo_confirm: "Are you sure?" } %>
   </div>

--- a/app/views/dokku/postgres_links/new.html.erb
+++ b/app/views/dokku/postgres_links/new.html.erb
@@ -1,0 +1,7 @@
+<%= turbo_frame_tag "new_postgre_link" do %>
+  <%= form_with url: dokku_postgre_links_path, scope: "postgres_link" do |f| %>
+    <%= f.select :app_name, options_for_select(@available_app_names) %>
+
+    <%= f.submit "Create link", class: "cursor-pointer mt-1 block link" %>
+  <% end %>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,9 @@ Rails.application.routes.draw do
     resources :apps do
       resources :app_logs, only: :index
     end
-    resources :postgres, param: :service
+    resources :postgres, param: :service do
+      resource :postgres_links, only: [:new, :create, :destroy], as: :links
+    end
   end
 
   root "dokku/apps#index"

--- a/spec/requests/dokku/postgres_links_spec.rb
+++ b/spec/requests/dokku/postgres_links_spec.rb
@@ -1,0 +1,49 @@
+require "rails_helper"
+
+RSpec.describe Dokku::PostgresLinksController do
+  let(:service) { Dokku::Postgres.new(service: "applogger_production") }
+
+  before do
+    allow(Dokku::Postgres).to receive(:new).and_return(service)
+    allow(service).to receive(:links).and_return(["applogger", "facebook"])
+    allow(Dokku::App).to receive(:all).and_return([
+      Dokku::App.new(name: "twitter"),
+      Dokku::App.new(name: "facebook"),
+      Dokku::App.new(name: "applogger")
+    ])
+  end
+
+  describe "GET /dokku/postgres/:postgre_service/postgres_links/new" do
+    subject { get new_dokku_postgre_links_path(service), headers: basic_authorization_header }
+
+    it "renders a form to link a postgres service to an app" do
+      subject
+      expect(response).to have_http_status(:ok)
+      assert_select "option", "twitter"
+      assert_select "option", {count: 0, text: "facebook"}
+      assert_select "option", {count: 0, text: "applogger"}
+    end
+  end
+
+  describe "POST /dokku/postgres/:postgre_service/postgres_links" do
+    subject { post dokku_postgre_links_path(service), params: params, headers: basic_authorization_header }
+
+    let(:params) do
+      {
+        postgres_link: {
+          app_name: "twitter"
+        }
+      }
+    end
+
+    before do
+      allow(service).to receive(:link).and_return(true)
+    end
+
+    it "links the postgres service to the app" do
+      expect(service).to receive(:link).with("twitter")
+      subject
+      expect(response).to redirect_to dokku_postgre_path(service)
+    end
+  end
+end

--- a/spec/requests/dokku/postgres_spec.rb
+++ b/spec/requests/dokku/postgres_spec.rb
@@ -41,6 +41,7 @@ RSpec.describe Dokku::PostgresController do
     before do
       allow(Dokku::Postgres).to receive(:new).and_return(testbox)
       allow(testbox).to receive(:info).and_return("testbox info")
+      allow(testbox).to receive(:links).and_return(["testboxapp", "another_app"])
     end
 
     it "renders a single postgres service" do
@@ -48,6 +49,8 @@ RSpec.describe Dokku::PostgresController do
       expect(response).to have_http_status(:ok)
       expect(response.body).to include("testbox")
       expect(response.body).to include("testbox info")
+      expect(response.body).to include("testboxapp")
+      expect(response.body).to include("another_app")
     end
 
     context "when the service has errors" do


### PR DESCRIPTION
Added Postgres#links to return all linked apps of a postgres service. Updated show action to display those linked apps.
Added .title as an @apply statement for tailwind to reuse title styling.
Creating a postgres link.
Using turbo frames to add link in place.

Next step is to be able to unlink a postgres service from an app.


https://user-images.githubusercontent.com/13257832/197935098-51689935-a9e2-4b01-ada0-1464b0cb3243.mov

